### PR TITLE
ladder update and typo fix

### DIFF
--- a/mod/arena-ladder.lua
+++ b/mod/arena-ladder.lua
@@ -3,18 +3,16 @@ ACT_LADDER = allocate_mario_action(ACT_GROUP_AIRBORNE | ACT_FLAG_AIR)
 
 -- behavior params:
 
--- ladder height|ladder orientation (0..3)
--- ex:  13881 <--
--- height^^|| orientation
--- 1388    .. 1
+-- ladder height
+-- ex:  1388
+-- object yaw = ladder yaw
 
 local sLadderClimb = 0
 
 ---@param obj Object
 function bhv_arena_ladder_init(obj)
     obj.hitboxRadius = 40
-    obj.hitboxHeight = math.floor(obj.oBehParams * 0.1)
-    obj.oFaceAngleYaw = (obj.oBehParams - math.floor(obj.oBehParams * 0.1) * 10) * 16384 - 32768
+    obj.hitboxHeight = obj.oBehParams
 end
 
 id_bhvArenaLadder = hook_behavior(nil, OBJ_LIST_LEVEL, true, bhv_arena_ladder_init, nil)
@@ -23,7 +21,7 @@ id_bhvArenaLadder = hook_behavior(nil, OBJ_LIST_LEVEL, true, bhv_arena_ladder_in
 function mario_check_for_ladder(m)
     local ladder = obj_get_nearest_object_with_behavior_id(m.marioObj, id_bhvArenaLadder)
     if ladder == nil then return end
-    if m.action & ACT_FLAG_ATTACKING ~= 0 and lateral_dist_between_objects(m.marioObj, ladder) < ladder.hitboxRadius + m.marioObj.hitboxRadius and m.pos.y < ladder.oPosY + ladder.hitboxHeight and m.pos.y > ladder.oPosY then
+    if m.action & ACT_FLAG_ATTACKING ~= 0 and lateral_dist_between_objects(m.marioObj, ladder) < ladder.hitboxRadius + m.marioObj.hitboxRadius and m.pos.y < ladder.oPosY + ladder.hitboxHeight and m.pos.y + m.marioObj.hitboxHeight > ladder.oPosY then
         set_mario_action(m, ACT_LADDER, 0)
     end
 end

--- a/mod/arena-ladder.lua
+++ b/mod/arena-ladder.lua
@@ -1,6 +1,5 @@
 ACT_LADDER = allocate_mario_action(ACT_GROUP_AIRBORNE | ACT_FLAG_AIR)
 
-
 -- behavior params:
 
 -- ladder height
@@ -23,12 +22,13 @@ function mario_check_for_ladder(m)
     if ladder == nil then return end
     if m.action & ACT_FLAG_ATTACKING ~= 0 and lateral_dist_between_objects(m.marioObj, ladder) < ladder.hitboxRadius + m.marioObj.hitboxRadius and m.pos.y < ladder.oPosY + ladder.hitboxHeight and m.pos.y + m.marioObj.hitboxHeight > ladder.oPosY then
         set_mario_action(m, ACT_LADDER, 0)
+        gMarioStateExtras[m.playerIndex].ladder = ladder
     end
 end
 
 ---@param m MarioState
 function act_ladder(m)
-    local ladder = obj_get_nearest_object_with_behavior_id(m.marioObj, id_bhvArenaLadder)
+    local ladder = gMarioStateExtras[m.playerIndex].ladder
 
     m.vel.x = 0
     m.vel.y = 0
@@ -65,6 +65,7 @@ function act_ladder(m)
     if (m.input & (INPUT_A_PRESSED | INPUT_B_PRESSED)) ~= 0 then
         set_mario_action(m,ACT_FREEFALL,0)
         m.vel.y = m.controller.rawStickY * 0.2
+        gMarioStateExtras[m.playerIndex].ladder = nil
     end
 end
 

--- a/mod/arena-player.lua
+++ b/mod/arena-player.lua
@@ -386,7 +386,7 @@ function mario_local_update(m)
 
     -- prevent water heal
     if m.health >= 0x100 then
-        if m.healthCounter == 0 and m.hurtCounter == 0 then
+        if m.healCounter == 0 and m.hurtCounter == 0 then
             if ((m.action & ACT_FLAG_SWIMMING ~= 0) and (m.action & ACT_FLAG_INTANGIBLE == 0)) then
                 if ((m.pos.y >= (m.waterLevel - 140)) and not (m.area.terrainType & TERRAIN_SNOW ~= 0)) then
                     m.health = m.health - 0x1A

--- a/mod/arena-player.lua
+++ b/mod/arena-player.lua
@@ -15,6 +15,7 @@ for i = 0, (MAX_PLAYERS - 1) do
     e.prevHurtCounter     = 0
     e.levelTimer          = 0
     e.levelTimerLevel     = 0
+    e.ladder              = nil
 
     local s = gPlayerSyncTable[i]
     s.item     = ITEM_NONE


### PR DESCRIPTION
the only behavior param now is ladder height
ladders' orientation (yaw) is now simply set by the object's yaw
when adding ladders in fast64, the cone empty is recommended
![image](https://github.com/djoslin0/coop-arena/assets/68075390/50ae59d4-3ba9-4cb8-8dde-285ce38558df)
mario can now climb ladders that are higher than him

healthCounter doesn't exist