### PR TITLE
no more ladder teleportation this time*

### DIFF
--- a/mod/arena-ladder.lua
+++ b/mod/arena-ladder.lua
@@ -7,27 +7,37 @@ ACT_LADDER = allocate_mario_action(ACT_GROUP_AIRBORNE | ACT_FLAG_AIR)
 -- object yaw = ladder yaw
 
 local sLadderClimb = 0
+local ladders = {}
 
 ---@param obj Object
 function bhv_arena_ladder_init(obj)
     obj.hitboxRadius = 40
     obj.hitboxHeight = obj.oBehParams
+    table.insert(ladders, obj)
 end
 
 id_bhvArenaLadder = hook_behavior(nil, OBJ_LIST_LEVEL, true, bhv_arena_ladder_init, nil)
 
 ---@param m MarioState
 function mario_check_for_ladder(m)
-    local ladder = obj_get_nearest_object_with_behavior_id(m.marioObj, id_bhvArenaLadder)
-    if ladder == nil then return end
-    if m.action & ACT_FLAG_ATTACKING ~= 0 and lateral_dist_between_objects(m.marioObj, ladder) < ladder.hitboxRadius + m.marioObj.hitboxRadius and m.pos.y < ladder.oPosY + ladder.hitboxHeight and m.pos.y + m.marioObj.hitboxHeight > ladder.oPosY then
-        set_mario_action(m, ACT_LADDER, 0)
-        gMarioStateExtras[m.playerIndex].ladder = ladder
+    if #ladders == 0 then return end
+    for i, ladder in pairs(ladders) do
+        if m.action & ACT_FLAG_ATTACKING ~= 0 and lateral_dist_between_objects(m.marioObj, ladder) < ladder.hitboxRadius + m.marioObj.hitboxRadius and m.pos.y < ladder.oPosY + ladder.hitboxHeight and m.pos.y + m.marioObj.hitboxHeight > ladder.oPosY then
+            set_mario_action(m, ACT_LADDER, 0)
+            gMarioStateExtras[m.playerIndex].ladder = ladder
+        end
     end
 end
 
 ---@param m MarioState
 function act_ladder(m)
+    if gMarioStateExtras[m.playerIndex].ladder == nil then
+        for i, ladder in pairs(ladders) do
+            if lateral_dist_between_objects(m.marioObj, ladder) < ladder.hitboxRadius + m.marioObj.hitboxRadius and m.pos.y < ladder.oPosY + ladder.hitboxHeight and m.pos.y + m.marioObj.hitboxHeight > ladder.oPosY then
+                gMarioStateExtras[m.playerIndex].ladder = ladder
+            end
+        end
+    end
     local ladder = gMarioStateExtras[m.playerIndex].ladder
 
     m.vel.x = 0
@@ -54,19 +64,22 @@ function act_ladder(m)
     if m.pos.y < ladder.oPosY then
         m.pos.y = ladder.oPosY
     end
-    if m.pos.y > ladder.oPosY or m.pos.y < ladder.oPosY + ladder.hitboxHeight then
-        sLadderClimb = sLadderClimb + math.abs(m.controller.rawStickY * 0.2)
-    end
-    if sLadderClimb > 128 then
-        sLadderClimb = 0
-        play_sound(SOUND_GENERAL_METAL_POUND, m.marioObj.header.gfx.cameraToObject)
-    end
-
     if (m.input & (INPUT_A_PRESSED | INPUT_B_PRESSED)) ~= 0 then
         set_mario_action(m,ACT_FREEFALL,0)
         m.vel.y = m.controller.rawStickY * 0.2
         gMarioStateExtras[m.playerIndex].ladder = nil
     end
+    if m.playerIndex ~= 0 then return end
+    if ladder.oPosY < m.pos.y and m.pos.y < ladder.oPosY + ladder.hitboxHeight then
+        sLadderClimb = sLadderClimb + math.abs(m.controller.rawStickY * 0.2)
+    end
+    if sLadderClimb > 128 and m.playerIndex == 0 then
+        sLadderClimb = 0
+        play_sound(SOUND_GENERAL_METAL_POUND, m.marioObj.header.gfx.cameraToObject)
+    end
 end
-
+function clearladders()
+    ladders = {}
+end
+hook_event(HOOK_ON_LEVEL_INIT,clearladders)
 hook_mario_action(ACT_LADDER, { every_frame = act_ladder })

--- a/mod/arena-ladder.lua
+++ b/mod/arena-ladder.lua
@@ -20,11 +20,11 @@ id_bhvArenaLadder = hook_behavior(nil, OBJ_LIST_LEVEL, true, bhv_arena_ladder_in
 
 ---@param m MarioState
 function mario_check_for_ladder(m)
-    if #ladders == 0 then return end
+    if not (m.action & ACT_FLAG_ATTACKING ~= 0) or #ladders == 0 then return end
     for i, ladder in pairs(ladders) do
-        if m.action & ACT_FLAG_ATTACKING ~= 0 and lateral_dist_between_objects(m.marioObj, ladder) < ladder.hitboxRadius + m.marioObj.hitboxRadius and m.pos.y < ladder.oPosY + ladder.hitboxHeight and m.pos.y + m.marioObj.hitboxHeight > ladder.oPosY then
-            set_mario_action(m, ACT_LADDER, 0)
+        if lateral_dist_between_objects(m.marioObj, ladder) < ladder.hitboxRadius + m.marioObj.hitboxRadius and m.pos.y < ladder.oPosY + ladder.hitboxHeight and m.pos.y + m.marioObj.hitboxHeight > ladder.oPosY then
             gMarioStateExtras[m.playerIndex].ladder = ladder
+            set_mario_action(m, ACT_LADDER, 0)
         end
     end
 end


### PR DESCRIPTION
on `HOOK_ON_LEVEL_INIT`, all ladders add themselves to a table
now the ladder check happens only if mario is attacking, so that we don't check for each ladder otherwise
if in `ACT_LADDER` and the player's ladder is nil, the same method used in `mario_check_for_ladder` is used
hopefully that's the last i'll see of it

*it happened only once while testing with the latest fixes