### PR TITLE
ladders have been improved

### DIFF
--- a/mod/arena-ladder.lua
+++ b/mod/arena-ladder.lua
@@ -83,8 +83,9 @@ function act_ladder(m)
         end
         if m.controller.rawStickY > 64 then
             set_mario_action(m,ACT_FORWARD_ROLLOUT,0)
-            m.forwardVel = 8
+            m.forwardVel = 10
             m.vel.y = 10
+            return
         end
         set_mario_action(m,ACT_WALL_KICK_AIR,0)
         m.faceAngle.y = m.faceAngle.y + 32768

--- a/mod/arena-ladder.lua
+++ b/mod/arena-ladder.lua
@@ -28,7 +28,7 @@ id_bhvArenaLadder = hook_behavior(nil, OBJ_LIST_LEVEL, true, bhv_arena_ladder_in
 ---@param m MarioState
 function mario_check_for_ladder(m)
     if m.action == ACT_FORWARD_ROLLOUT and m.prevAction == ACT_LADDER then
-        m.forwardVel = 8
+        m.forwardVel = 10
     end
     if not (m.action & ACT_FLAG_ATTACKING ~= 0) or #ladders == 0 or m.action == ACT_LADDER then return end
     for i, ladder in pairs(ladders) do
@@ -77,9 +77,14 @@ function act_ladder(m)
         if math.abs(m.controller.rawStickX) > 64 then
             set_mario_action(m,ACT_FORWARD_ROLLOUT,0)
             m.faceAngle.y = m.faceAngle.y - 16384*math.abs(x)/x
-            m.forwardVel = 8
+            m.forwardVel = 10
             m.vel.y = 10
             return
+        end
+        if m.controller.rawStickY > 64 then
+            set_mario_action(m,ACT_FORWARD_ROLLOUT,0)
+            m.forwardVel = 8
+            m.vel.y = 10
         end
         set_mario_action(m,ACT_WALL_KICK_AIR,0)
         m.faceAngle.y = m.faceAngle.y + 32768

--- a/mod/arena-ladder.lua
+++ b/mod/arena-ladder.lua
@@ -9,6 +9,13 @@ ACT_LADDER = allocate_mario_action(ACT_GROUP_AIRBORNE | ACT_FLAG_AIR)
 local sLadderClimb = 0
 local ladders = {}
 
+gPlayerSyncTable[0].ladder = {}
+gPlayerSyncTable[0].ladder.x = nil
+gPlayerSyncTable[0].ladder.y = nil
+gPlayerSyncTable[0].ladder.z = nil
+gPlayerSyncTable[0].ladder.height = nil
+gPlayerSyncTable[0].ladder.angle = nil
+
 ---@param obj Object
 function bhv_arena_ladder_init(obj)
     obj.hitboxRadius = 40
@@ -20,10 +27,17 @@ id_bhvArenaLadder = hook_behavior(nil, OBJ_LIST_LEVEL, true, bhv_arena_ladder_in
 
 ---@param m MarioState
 function mario_check_for_ladder(m)
-    if not (m.action & ACT_FLAG_ATTACKING ~= 0) or #ladders == 0 then return end
+    if m.action == ACT_FORWARD_ROLLOUT and m.prevAction == ACT_LADDER then
+        m.forwardVel = 8
+    end
+    if not (m.action & ACT_FLAG_ATTACKING ~= 0) or #ladders == 0 or m.action == ACT_LADDER then return end
     for i, ladder in pairs(ladders) do
         if lateral_dist_between_objects(m.marioObj, ladder) < ladder.hitboxRadius + m.marioObj.hitboxRadius and m.pos.y < ladder.oPosY + ladder.hitboxHeight and m.pos.y + m.marioObj.hitboxHeight > ladder.oPosY then
-            gMarioStateExtras[m.playerIndex].ladder = ladder
+            gPlayerSyncTable[m.playerIndex].ladder.x = ladder.oPosX
+            gPlayerSyncTable[m.playerIndex].ladder.y = ladder.oPosY
+            gPlayerSyncTable[m.playerIndex].ladder.z = ladder.oPosZ
+            gPlayerSyncTable[m.playerIndex].ladder.height = ladder.hitboxHeight
+            gPlayerSyncTable[m.playerIndex].ladder.angle = ladder.oFaceAngleYaw
             set_mario_action(m, ACT_LADDER, 0)
         end
     end
@@ -31,14 +45,9 @@ end
 
 ---@param m MarioState
 function act_ladder(m)
-    if gMarioStateExtras[m.playerIndex].ladder == nil then
-        for i, ladder in pairs(ladders) do
-            if lateral_dist_between_objects(m.marioObj, ladder) < ladder.hitboxRadius + m.marioObj.hitboxRadius and m.pos.y < ladder.oPosY + ladder.hitboxHeight and m.pos.y + m.marioObj.hitboxHeight > ladder.oPosY then
-                gMarioStateExtras[m.playerIndex].ladder = ladder
-            end
-        end
-    end
-    local ladder = gMarioStateExtras[m.playerIndex].ladder
+    local ladder = gPlayerSyncTable[m.playerIndex].ladder
+    local x = m.controller.rawStickX
+    local y = m.controller.rawStickY
 
     m.vel.x = 0
     m.vel.y = 0
@@ -47,31 +56,45 @@ function act_ladder(m)
 
     perform_air_step(m, 0)
 
-    m.pos.x = ladder.oPosX
-    m.pos.z = ladder.oPosZ
+    m.pos.x = ladder.x
+    m.pos.z = ladder.z
 
     set_mario_animation(m, MARIO_ANIM_BEING_GRABBED)
     local loop = m.marioObj.header.gfx.animInfo.curAnim.loopEnd
     set_anim_to_frame(m, m.pos.y/10 - math.floor(m.pos.y / 10 / loop) * loop)
 
     m.marioObj.header.gfx.angle.x = 8192
-    m.faceAngle.y = ladder.oFaceAngleYaw
+    m.faceAngle.y = ladder.angle
 
-    m.pos.y = m.pos.y + m.controller.rawStickY*.2
-    if m.pos.y > ladder.oPosY + ladder.hitboxHeight then
-        m.pos.y = ladder.oPosY + ladder.hitboxHeight
+    m.pos.y = m.pos.y + y*.2
+    if m.pos.y > ladder.y + ladder.height then
+        m.pos.y = ladder.y + ladder.height
     end
-    if m.pos.y < ladder.oPosY then
-        m.pos.y = ladder.oPosY
+    if m.pos.y < ladder.y then
+        m.pos.y = ladder.y
     end
-    if (m.input & (INPUT_A_PRESSED | INPUT_B_PRESSED)) ~= 0 then
+    if m.input & INPUT_A_PRESSED ~= 0 then
+        if math.abs(m.controller.rawStickX) > 64 then
+            set_mario_action(m,ACT_FORWARD_ROLLOUT,0)
+            m.faceAngle.y = m.faceAngle.y - 16384*math.abs(x)/x
+            m.forwardVel = 8
+            m.vel.y = 10
+            return
+        end
+        set_mario_action(m,ACT_WALL_KICK_AIR,0)
+        m.faceAngle.y = m.faceAngle.y + 32768
+        m.forwardVel = 30
+        m.vel.y = 50
+        return
+    end
+    if m.input & INPUT_Z_PRESSED ~= 0 then
         set_mario_action(m,ACT_FREEFALL,0)
-        m.vel.y = m.controller.rawStickY * 0.2
-        gMarioStateExtras[m.playerIndex].ladder = nil
+        m.vel.y = y * 0.2
+        return
     end
     if m.playerIndex ~= 0 then return end
-    if ladder.oPosY < m.pos.y and m.pos.y < ladder.oPosY + ladder.hitboxHeight then
-        sLadderClimb = sLadderClimb + math.abs(m.controller.rawStickY * 0.2)
+    if ladder.y < m.pos.y and m.pos.y < ladder.y + ladder.height then
+        sLadderClimb = sLadderClimb + math.abs(y * 0.2)
     end
     if sLadderClimb > 128 and m.playerIndex == 0 then
         sLadderClimb = 0

--- a/mod/arena-player.lua
+++ b/mod/arena-player.lua
@@ -15,7 +15,6 @@ for i = 0, (MAX_PLAYERS - 1) do
     e.prevHurtCounter     = 0
     e.levelTimer          = 0
     e.levelTimerLevel     = 0
-    e.ladder              = nil
 
     local s = gPlayerSyncTable[i]
     s.item     = ITEM_NONE


### PR DESCRIPTION
aside from ladder teleportation finally being dealt with (and hopefully being gone for good),
# new feature!
There are two new options when dismounting ladders:
## Rollout
Press A while holding the control stick left or right to rollout in that direction

![spin](https://github.com/djoslin0/coop-arena/assets/68075390/3fe0a98a-bb91-4af0-95f6-2a6061c04fb0)

## Wall Kick
Simply press A to wall kick off the ladder

![wallkick](https://github.com/djoslin0/coop-arena/assets/68075390/9f80ca49-d328-4ba0-a1a2-1641758a17af)
#

Freefall has been relocated to Z, and B doesn't do anything (yet..).